### PR TITLE
small code review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+target/
+
+PACAS_index_*/
+output/
+files_to_index/

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ git clone https://github.com/Yohan-HernandezCourbevoie/REINDEER2.git
 Then build :
 
 ```
-cd REINDEER2 && cargo build
+cd REINDEER2 && RUSTFLAGS="-C target-cpu=native" cargo build --release
 ```
 
 Alternatively, the tool can be installed globally in the system using :

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,6 @@
-use clap::{Arg, ArgAction, Command, ArgMatches};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 
+// TODO discuss utiliser un struct ici
 pub fn parse_args() -> ArgMatches {
     Command::new("REINDEER 2")
         .bin_name("Reindeer2")


### PR DESCRIPTION
Hello !

J'ai un peu relu le code histoire de me faire la main dessus. J'en ai profiter pour proposer quelques modifications, histoire de voir si je comprends bien le code.

J'ai tendance à être un peu direct, dis moi si je suis trop froid.

# Remarques générales
Il y a quelques endroits ou il a des des indirections non nécessaires, par example des references vers des references, des ou `Box<Vec<T>>` ou des `&String`. Même si le compilateur peut parfois enlever ça tout seul, ça rend le code plus difficile à utiliser / lire.

## Example de bonne pratique: remplacer `&String` par `&str` et `&Vec<T>` par `&[T]`.
`String` est déjà une indirection vers un `char *` (si tu viens de C/C++), donc prendre `&String` ne fait que déréfencer deux fois au lieu d'une. Pareil pour `Vec` et `[_]`. En plus, utiliser `&str` permet d'accepter `"coucou"` en paramètre, alors que `&String` ne prends que `String::from("coucou")`.

# Remarques en vrac
On peut [utiliser des structs et des enums](https://github.com/clap-rs/clap/blob/master/examples/escaped-positional-derive.rs) pour parser les arguements du programme. Ça évite de devoir parser les String à la main, de devoir rensigner qui sont les autheurs, et ça évite les oublis. Tu as déjà essayé ? Je peux l'ajouter au besoin, c'est assez rapide.

Il y a des appels à `.ok();` qui, il me semble, n'ont pas d'effet (j'ai mis un TODO pour que tui puisses faire un CTRL+f). Tu voulais faire quoi ?

Il y a des magic numbers un peu partout (ex: 666). C'est une mauvaise pratique, mais je sais pas trop comment changer ça. On peut en discuter, et si on trouve pas de solution, je propose d'au moins utiliser une constante.

# Modifs proposée, du plus sur de moi au moins sur de moi:
Il y avait quelques
```rust
match X {
    Some(Y) => //
    None => ()
}
```
J'ai remplacé par
```rust
if let Some(Y) = X {
    //
}
```

J'ai ajouté `#[cfg(test)]` devant le module de test. Comme ça il disparait à la compilation en production.

J'ai remplacé `(total_colors + magic_nb_split - 1) / magic_nb_split` par `total_colors.div_ceil(magic_nb_split)`

J'ai réécrit `flush_map` en une fonction (au lieu d'une lamdba). Ça permet de mieux la voir sur mes benchs. Dis moi si c'est un problème. 

J'ai remplacé les `.or_insert_with(Vec::new)` par `or_default()`. Question de style je suppose, si ça te vas pas je revert.

J'ai remplacé les `Err(io::Error::new(io::ErrorKind::Other` par `Err(io::Error::other(`

fonction `explore_muset_dir`:
- Changé le type de retour (ne renvoyais jamais d'erreur)
- Changé le calcul de `color_nb`, dis moi si c'est OK (normalement c'est équivalent, mais plus rapide)