### PR TITLE
Add ability to select non canonical k-mers when indexing/querying

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The generale use of REINDEER 2 is divided in to steps : index building and abund
 
 For the **index** mode, the mandatory parameters are the file of files (a plain text file where each line represented a unitigs file) and the size of the k-mers to be indexed.
 
-`Reindeer2 --mode index --input file_of_files.txt --kmer 31`
+`Reindeer2 index --input file_of_files.txt --kmer 31`
 
 
 General parameters:
@@ -68,11 +68,14 @@ Advanced parameters:
 
 For **query** mode, the parameters are the FASTA file containing the sequence(s) to be queried and the index directory.
 
-`Reindeer2 --mode query --fasta sequences_query.fa --index ~/index_directory`
+`Reindeer2 query --fasta sequences_query.fa --index ~/index_directory`
 
 Optional parameters:
-- `-c, --color` (true/false) is used to annotate the input file with abundances rather than producing the standard output file (as showed in the examples below) (default: false)
-- `-n, --normalize` (true/false) parameter allows to normalize abundances based on sequencing depth estimates. The calculation is _normalized\_abundance = raw\_abundance / number\_of\_kmers\_in\_the\_dataset * 1\_000\_000_ (default: false)
+- `--output-format` allows to change the output format. Suported formats are:
+    - `median` (default): for each color, returns the median of k-mer abundance per read
+    - `normalized-median`: normalize abundances based on sequencing depth estimates. The calculation is _normalized\_abundance = raw\_abundance / number\_of\_kmers\_in\_the\_dataset * 1\_000\_000_
+    - `colored`: annotate the input file with abundances rather than producing the standard output file (as showed in the examples below)
+    - `raw`: for each color, for each read, returns the abundance of every k-mer (similar to REINDEER 1).
 - `-C, --coverage-min` minimum proportion of kmers that must be present in the query sequence in order to propose an abundance value
 
 #### CSV file with --color false (default)
@@ -90,13 +93,13 @@ To illustrate how the tool works, a small example is available. The commands are
 #### INDEX
 How to build the index:
 ```
-Reindeer2 --mode index --input test_files/fof.txt --kmer 31 --output-dir ../index_test
+Reindeer2 index --input test_files/fof.txt --kmer 31 --output-dir ../index_test
 ```
 
 #### QUERY (results: CSV)
 With the command:
 ```
-Reindeer2 --mode query --fasta test_files/file1Q.fa --index ../index_test
+Reindeer2 query --fasta test_files/file1Q.fa --index ../index_test
 cat ../index_test/query_results.csv
 ```
 is expected the result:
@@ -112,7 +115,7 @@ header,file,abundance
 #### QUERY (results: colored graph FASTA)
 With the command:
 ```
-Reindeer2 --mode query --fasta test_files/file1Q.fa --index ../index_test --color true 
+Reindeer2 query --fasta test_files/file1Q.fa --index ../index_test --output-format colored 
 cat ../index_test/colored_graph.fa
 ```
 is expected the result:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{ArgAction, Args, Parser, Subcommand};
+use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 
 #[derive(Parser, Debug)]
 // #[command(disable_version_flag = true, disable_help_flag = true)]// TODO discuss
@@ -110,6 +110,14 @@ pub struct IndexArgs {
     pub output_dir: Option<String>,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, ValueEnum)]
+pub enum OutputFormat {
+    Colored,
+    NormalizedMedian,
+    Median,
+    Raw,
+}
+
 #[derive(Args, Debug)]
 pub struct QueryArgs {
     /// Path to the FASTA file containing query sequences
@@ -120,17 +128,9 @@ pub struct QueryArgs {
     #[arg(short = 'i', long = "index", value_name = "DIR")]
     pub index: String,
 
-    /// bool for coloring a graph instead of regular query (default: false)
-    #[arg(short = 'c', long = "color", default_value_t = false)]
-    pub color: bool,
-
-    /// bool for normalizing abundances based on sequencing depth estimates (default: false)
-    #[arg(short = 'n', long = "normalize", default_value_t = false)]
-    pub normalize: bool,
-
-    /// Print abundace per k-mer, like REINDEER 1? (default: false)
-    #[arg(long, default_value_t = false)]
-    pub rd1_like: bool,
+    /// Precision of the format output
+    #[arg(long, value_enum, default_value_t = OutputFormat::Median)]
+    pub output_format: OutputFormat,
 
     /// Minimum proportion of kmers that must be present in the query sequence in order to propose an abundance value, 0 < C <= 1 (default: 0.5)
     #[arg(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 #[derive(Parser, Debug)]
 // #[command(disable_version_flag = true, disable_help_flag = true)]// TODO discuss

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -108,6 +108,10 @@ pub struct IndexArgs {
     /// Sets the index output directory (default: random name in the form of PACAS_index_)
     #[arg(short = 'o', long = "output-dir", value_name = "OUT")]
     pub output_dir: Option<String>,
+
+    /// Use canonical version of k-mers (default: true)
+    #[arg(long, default_value_t = true)]
+    pub canonical: bool,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, ValueEnum)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use rand::Rng;
 use std::io::{self};
 use std::time::Instant;
 
+use crate::cli::OutputFormat;
 use crate::reindeer2::{build_index_muset, explore_muset_dir, read_fof_file, Reindeer2};
 use cli::Cli;
 
@@ -118,17 +119,15 @@ fn main() -> io::Result<()> {
 
             let fasta_file = args.fasta;
             let index_dir = args.index;
-            let color_graph = args.color;
             let coverage = args.coverage;
-            let normalize_option = args.normalize;
-            let rd1_like = args.rd1_like;
+            let output_format = args.output_format;
 
             println!("Index directory: {}", index_dir);
 
-            let mut query_output = format!("{}/query_results.csv", index_dir);
-            if color_graph {
-                query_output = format!("{}/colored_graph.fa", index_dir);
-            }
+            let query_output = match output_format {
+                OutputFormat::Colored => format!("{}/colored_graph.fa", index_dir),
+                _ => format!("{}/query_results.csv", index_dir),
+            };
 
             let start_time = Instant::now();
             let index = Reindeer2::from_csv(&index_dir)
@@ -138,10 +137,8 @@ fn main() -> io::Result<()> {
                     &fasta_file,
                     &index_dir,
                     &query_output,
-                    color_graph,
-                    normalize_option,
+                    output_format,
                     coverage,
-                    rd1_like,
                 )
                 .expect("Failed to query sequences");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ fn main() -> io::Result<()> {
             let abundance = args.abundance;
             let abundance_max = args.abundance_max;
             let dense_option = args.dense;
+            let canonical = args.canonical;
             let output_dir = args.output_dir.unwrap_or_else(|| {
                 format!("PACAS_index_{}", rand::thread_rng().gen::<u64>()) // Generate a unique directory name
             });
@@ -82,6 +83,7 @@ fn main() -> io::Result<()> {
                     &output_dir,
                     dense_option,
                     tolerated_number_of_zeros,
+                    canonical,
                     debug,
                 )?;
             } else {
@@ -98,6 +100,7 @@ fn main() -> io::Result<()> {
                     abundance,
                     abundance_max,
                     dense_option,
+                    canonical,
                 );
                 index.build(
                     file_paths,

--- a/src/reindeer2/index.rs
+++ b/src/reindeer2/index.rs
@@ -113,8 +113,7 @@ pub fn process_fasta_file(
                                     } else if path_num_global <= threshold {
                                         // create a new abundance vector for the k-mer
                                         let mut abundance_vector: Vec<u8> =
-                                            Vec::with_capacity(color_number_global);
-                                        abundance_vector.resize(color_number_global, 0);
+                                            vec![0; color_number_global];
                                         abundance_vector[path_num_global] =
                                             (log_abundance + 1) as u8;
                                         dense_index.insert(kmer_hash, abundance_vector);

--- a/src/reindeer2/index.rs
+++ b/src/reindeer2/index.rs
@@ -34,6 +34,7 @@ pub fn process_fasta_file(
     atomic_dense_kmers_count: &atomic::AtomicU64,
     atomic_sparse_kmers_count: &atomic::AtomicU64,
     kmer_counts_vector: &Arc<Mutex<Vec<usize>>>,
+    canonical: bool,
 ) -> io::Result<()> {
     let atomic_record_count = atomic::AtomicU64::new(0);
     let mut kmer_count: usize = 0;
@@ -86,7 +87,7 @@ pub fn process_fasta_file(
                         let seq_str = std::str::from_utf8(&seq).expect("Invalid UTF-8 sequence");
 
                         for (kmer_hash, minimizer) in
-                            kmer_minimizers_seq_level(seq_str.as_bytes(), k, m)
+                            kmer_minimizers_seq_level(seq_str.as_bytes(), k, m, canonical)
                         {
                             kmer_count += count_value as usize;
                             //for (kmer_hash, (minimizer, _)) in nt_hash_iterator.zip(min_iter) { // iterate on both minimizer and hash for each kmer

--- a/src/reindeer2/mod.rs
+++ b/src/reindeer2/mod.rs
@@ -62,7 +62,7 @@ impl Reindeer2 {
 
     pub fn from_csv(bf_dir: &str) -> io::Result<Self> {
         //load index metadata from CSV
-        println!("Loaded index metadata for query.");
+        println!("Loading index metadata for query.");
         let (
             k,
             m,

--- a/src/reindeer2/mod.rs
+++ b/src/reindeer2/mod.rs
@@ -18,6 +18,8 @@ use std::time::Instant;
 use thousands::Separable;
 use zstd::stream::decode_all;
 
+use crate::OutputFormat;
+
 // === INDEX ===
 
 pub struct Reindeer2 {
@@ -221,8 +223,8 @@ impl Reindeer2 {
         if debug {
             // k-mers repartition between dense and sparse index
             println!("The index contains {:?} 'dense' k-mers and {:?} 'sparse' k-mers (total k-mers: {:?})", 
-            atomic_dense_kmers_count.get_mut().separate_with_commas(), 
-            atomic_sparse_kmers_count.get_mut().separate_with_commas(), 
+            atomic_dense_kmers_count.get_mut().separate_with_commas(),
+            atomic_sparse_kmers_count.get_mut().separate_with_commas(),
             total_kmers.get_mut().separate_with_commas());
 
             let ones = atomic_sparse_one_seen.get_mut();
@@ -230,9 +232,9 @@ impl Reindeer2 {
             let fp = atomic_sparse_fp_seen.get_mut();
             // k-mers indexed in the sparse index, FP silent and FP seen
             println!("Among the {:?} k-mers added in the 'sparse' index, {:?} encountered hash collisions ({:?} silent and {:?} misleading).", 
-            atomic_sparse_kmers_count.get_mut().separate_with_commas(), 
+            atomic_sparse_kmers_count.get_mut().separate_with_commas(),
             (silent+*fp).separate_with_commas(),
-            silent.separate_with_commas(), 
+            silent.separate_with_commas(),
             fp.separate_with_commas());
         }
 
@@ -285,10 +287,8 @@ impl Reindeer2 {
         fasta_file: &str,
         bf_dir: &str,
         output_file: &str,
-        color_graph: bool,
-        normalize_option: bool,
+        output_format: OutputFormat,
         coverage: f32,
-        rd1_like: bool,
     ) -> io::Result<()> {
         let query_results = query::query_sequences_in_batches(
             fasta_file,
@@ -302,11 +302,9 @@ impl Reindeer2 {
             self.abundance_max,
             10_000_000,
             &output_file,
-            color_graph,
             self.dense_option,
-            normalize_option,
+            output_format,
             coverage,
-            rd1_like,
         )?;
         println!("Writing results in {}", output_file);
         //write_query_results_to_csv(&query_results, bf_dir)
@@ -549,9 +547,9 @@ pub fn build_index_muset(
         let fp = atomic_sparse_fp_seen.get_mut();
         // k-mers indexed in the sparse index, FP silent and FP seen
         println!("Among the {:?} k-mers added in the 'sparse' index, {:?} encountered hash collisions ({:?} silent and {:?} misleading).", 
-            atomic_sparse_kmers_count.get_mut().separate_with_commas(), 
+            atomic_sparse_kmers_count.get_mut().separate_with_commas(),
             (silent+*fp).separate_with_commas(),
-            silent.separate_with_commas(), 
+            silent.separate_with_commas(),
             fp.separate_with_commas());
     }
 
@@ -2074,13 +2072,7 @@ mod tests {
             dense_option,
         );
         let (_file_paths, index_dir) = index
-            .build(
-                file_paths.clone(),
-                test_dir,
-                dense_option,
-                threshold,
-                false,
-            )
+            .build(file_paths.clone(), test_dir, dense_option, threshold, false)
             .expect("Failed to build index");
 
         let query_results_path = format!("{}/query_results.csv", index_dir);

--- a/src/reindeer2/mod.rs
+++ b/src/reindeer2/mod.rs
@@ -4,7 +4,7 @@ mod query;
 use bio::io::fasta;
 use csv::Writer;
 use flate2::read::GzDecoder;
-use nthash::NtHashIterator;
+use nthash::{NtHashForwardIterator, NtHashIterator};
 use num_format::{Locale, ToFormattedString};
 use rayon::prelude::*;
 use roaring::RoaringBitmap;
@@ -31,6 +31,7 @@ pub struct Reindeer2 {
     abundance_number: usize,
     abundance_max: u16,
     dense_option: bool,
+    canonical: bool,
 }
 
 impl Reindeer2 {
@@ -44,6 +45,7 @@ impl Reindeer2 {
         abundance_max: u16,
         // TODO rename is_dense
         dense_option: bool,
+        canonical: bool,
     ) -> Self {
         Self {
             bf_size,
@@ -54,6 +56,7 @@ impl Reindeer2 {
             abundance_max,
             abundance_number,
             dense_option,
+            canonical,
         }
     }
 
@@ -69,6 +72,7 @@ impl Reindeer2 {
             abundance_number,
             abundance_max,
             dense_option,
+            canonical,
         ) = read_partition_from_csv(bf_dir, "index_info.csv")?;
         Ok(Self {
             bf_size,
@@ -79,6 +83,7 @@ impl Reindeer2 {
             abundance_number,
             abundance_max,
             dense_option,
+            canonical,
         })
     }
 
@@ -180,6 +185,7 @@ impl Reindeer2 {
                                     &atomic_dense_kmers_count,
                                     &atomic_sparse_kmers_count,
                                     &kmer_counts_vector,
+                                    self.canonical,
                                 ) {
                                     eprintln!("Error processing {}: {}", path, e);
                                 }
@@ -275,6 +281,7 @@ impl Reindeer2 {
             self.abundance_number,
             self.abundance_max,
             dense_option,
+            self.canonical,
         );
 
         Ok((file_paths, dir_path))
@@ -305,6 +312,7 @@ impl Reindeer2 {
             self.dense_option,
             output_format,
             coverage,
+            self.canonical,
         )?;
         println!("Results written to {}", output_file);
         //write_query_results_to_csv(&query_results, bf_dir)
@@ -351,6 +359,7 @@ pub fn build_index_muset(
     output_dir: &str,
     dense_option: bool,
     threshold: usize,
+    canonical: bool,
     debug: bool,
 ) -> io::Result<(Vec<String>, String)> {
     let mut total_kmers = atomic::AtomicU64::new(0);
@@ -452,7 +461,7 @@ pub fn build_index_muset(
         let unitig_line = unitigs_lines.next().unwrap().unwrap();
         let seq_str = unitig_line.trim();
         for (kmer_hash, minimizer) in
-            kmer_minimizers_seq_level(seq_str.as_bytes(), kmer_size, minimizer_size)
+            kmer_minimizers_seq_level(seq_str.as_bytes(), kmer_size, minimizer_size, canonical)
         {
             let partition_index = (minimizer % (partition_number as u64)) as usize;
             let new_kmers_added = (abundance_vector_plusone.len() - number_of_zeros) as u64;
@@ -578,6 +587,7 @@ pub fn build_index_muset(
         abundance_number,
         abundance_max,
         dense_option,
+        canonical,
     );
 
     Ok((vec!["".to_string()], dir_path))
@@ -1150,6 +1160,7 @@ fn write_partition_to_csv(
     abundance_number: usize,
     abundance_max: u16,
     dense_option: bool,
+    canonical: bool,
 ) -> io::Result<()> {
     let output_path = format!("{}/index_info.csv", bf_dir);
 
@@ -1164,6 +1175,7 @@ fn write_partition_to_csv(
         "abundance_number",
         "abundance_max",
         "dense_option",
+        "canonical",
     ])?;
     csv_writer.write_record(&[
         k.to_string(),
@@ -1174,6 +1186,7 @@ fn write_partition_to_csv(
         abundance_number.to_string(),
         abundance_max.to_string(),
         dense_option.to_string(),
+        canonical.to_string(),
     ])?;
 
     println!("Index information written to {}", output_path);
@@ -1218,7 +1231,7 @@ fn load_dense_index(file_path: &str) -> io::Result<HashMap<u64, Box<Vec<u8>>>> {
 fn read_partition_from_csv(
     bf_dir: &str,
     output_csv: &str,
-) -> io::Result<(usize, usize, u64, usize, usize, usize, u16, bool)> {
+) -> io::Result<(usize, usize, u64, usize, usize, usize, u16, bool, bool)> {
     let csv_path = format!("{}/{}", bf_dir, output_csv);
     let mut reader = csv::Reader::from_reader(BufReader::new(File::open(csv_path)?));
     let values = reader.records().next().expect("Index CSV is empty")?;
@@ -1230,6 +1243,7 @@ fn read_partition_from_csv(
     let abundance_number = values[5].parse().unwrap_or(0);
     let abundance_max = values[6].parse().unwrap_or(0);
     let dense_option = values[7].parse().unwrap_or(false);
+    let canonical = values[8].parse().unwrap_or(true);
 
     Ok((
         k,
@@ -1240,6 +1254,7 @@ fn read_partition_from_csv(
         abundance_number,
         abundance_max,
         dense_option,
+        canonical,
     ))
 }
 
@@ -1511,6 +1526,7 @@ fn kmer_minimizers_seq_level<'a>(
     seq: &'a [u8],
     k: usize,
     m: usize,
+    canonical: bool,
 ) -> impl Iterator<Item = (u64, u64)> + 'a {
     assert!(
         seq.len() >= k,
@@ -1521,11 +1537,15 @@ fn kmer_minimizers_seq_level<'a>(
     assert!(k >= m, "k must be greater than or equal to m");
 
     //  collects the hash of every m-mer in the sequence w/ rolling hash
-    let m_hashes: Vec<u64> = NtHashIterator::new(seq, m)
-        .unwrap_or_else(|err| {
-            panic!("Error creating NtHashIterator for m-mers: {:?}", err);
-        })
-        .collect();
+    let m_hashes: Vec<u64> = if canonical {
+        NtHashIterator::new(seq, m)
+            .expect("should have been able to create canonical hash iterator")
+            .collect()
+    } else {
+        NtHashForwardIterator::new(seq, m)
+            .expect("should have been able to create hash iterator")
+            .collect()
+    };
 
     // compute sliding window to find minimums over m-mer hashes
     // for each k-mer starting at position i, the m-mers inside it are:
@@ -1612,10 +1632,18 @@ fn kmer_minimizers_seq_level<'a>(
     // at this point, the number of minima should equal the number of k-mers !!
     //assert_eq!(minima.len(), seq.len() - k + 1); //todo remove
 
-    let kmer_hash_iter = NtHashIterator::new(seq, k) // hash kmers
-    .unwrap_or_else(|err| {
-        panic!("Error creating NtHashIterator for k-mers: {:?}", err)
-    });
+    let kmer_hash_iter: Box<dyn Iterator<Item = u64>> = if canonical {
+        Box::new(
+            NtHashIterator::new(seq, k)
+                .expect("should have been able to create canonical hash iterator"),
+        )
+    } else {
+        Box::new(
+            NtHashForwardIterator::new(seq, k)
+                .expect("should have been able to create hash iterator"),
+        )
+    };
+
     // return an iterator over (hashed k-mers,corresponding minimizers)
     kmer_hash_iter.zip(minima)
 }
@@ -1877,8 +1905,10 @@ mod tests {
 
         let k = 7;
         let m = 3;
+        let canonical = true;
 
-        let pairs: Vec<(u64, u64)> = kmer_minimizers_seq_level(seq_bytes, k, m).collect();
+        let pairs: Vec<(u64, u64)> =
+            kmer_minimizers_seq_level(seq_bytes, k, m, canonical).collect();
 
         // there should be seq.len() - k + 1 pairs.
         assert_eq!(pairs.len(), seq_bytes.len() - k + 1);
@@ -1988,6 +2018,7 @@ mod tests {
         let abundance_number = 2;
         let abundance_max = 512;
         let dense_option = false;
+        let canonical = false;
 
         fs::create_dir_all(bf_dir).expect("Failed to create test directory");
 
@@ -2001,6 +2032,7 @@ mod tests {
             abundance_number,
             abundance_max,
             dense_option,
+            canonical,
         );
         assert!(write_result.is_ok(), "Failed to write CSV");
 
@@ -2016,6 +2048,7 @@ mod tests {
             read_abundance_number,
             read_abundance_max,
             read_dense_option,
+            read_canonical,
         ) = read_result.unwrap();
 
         assert_eq!(read_k, k, "Mismatch in k value");
@@ -2041,6 +2074,7 @@ mod tests {
             read_dense_option, dense_option,
             "Mismatch in dense_option value"
         );
+        assert_eq!(read_canonical, canonical, "Mismatch in canonical value");
 
         fs::remove_dir_all(bf_dir).expect("Failed to remove test directory");
     }
@@ -2070,6 +2104,7 @@ mod tests {
             abundance_number,
             abundance_max,
             dense_option,
+            true,
         );
         let (_file_paths, index_dir) = index
             .build(file_paths.clone(), test_dir, dense_option, threshold, false)
@@ -2132,6 +2167,7 @@ mod tests {
             abundance_number,
             abundance_max,
             dense_option,
+            false,
         );
         let (_file_paths, index_dir) = index
             .build(
@@ -4125,6 +4161,7 @@ mod tests {
             abundance_number,
             abundance_max,
             dense_option,
+            false,
         );
 
         let (_file_paths, index_dir) = index

--- a/src/reindeer2/mod.rs
+++ b/src/reindeer2/mod.rs
@@ -1445,7 +1445,7 @@ fn compute_base(abundance_number: usize, abundance_max: u16) -> f64 {
         panic!("abundance number must be greater than 0");
     }
 
-    // TODO pourquoi <= et pas == ?
+    #[expect(clippy::absurd_extreme_comparisons)]
     if abundance_max <= 0 {
         panic!("Maximal abundance must be greater than 0");
     }

--- a/src/reindeer2/mod.rs
+++ b/src/reindeer2/mod.rs
@@ -301,12 +301,12 @@ impl Reindeer2 {
             self.abundance_number,
             self.abundance_max,
             10_000_000,
-            &output_file,
+            output_file,
             self.dense_option,
             output_format,
             coverage,
         )?;
-        println!("Writing results in {}", output_file);
+        println!("Results written to {}", output_file);
         //write_query_results_to_csv(&query_results, bf_dir)
         Ok(query_results)
     }
@@ -2084,10 +2084,8 @@ mod tests {
                 &file_paths[query_file_id],
                 &index_dir,
                 &query_results_path,
-                false,
-                false,
+                OutputFormat::Median,
                 0.5,
-                false,
             )
             .expect("Failed to query sequences");
         query_results_path
@@ -2154,10 +2152,8 @@ mod tests {
                 &file1_path,
                 &index_dir,
                 &query_results_path,
-                false,
-                false,
+                OutputFormat::Median,
                 0.5,
-                false,
             )
             .expect("Failed to query sequences");
 
@@ -4148,10 +4144,8 @@ mod tests {
                 &fasta_path,
                 test_dir,
                 &output_path,
-                true, //  graph coloring
-                false,
+                OutputFormat::Colored,
                 0.5,
-                false,
             )
             .expect("Failed to color graph");
 

--- a/src/reindeer2/query.rs
+++ b/src/reindeer2/query.rs
@@ -182,6 +182,144 @@ fn load_kmer_counts_vector(dir_path: &str) -> io::Result<Vec<usize>> {
     Ok(counts_vector)
 }
 
+/// Write abundances per kmer like RD1.
+fn write_raw_abundance(
+    bf_dir: &str,
+    sequence_results: &HashMap<String, Vec<Vec<u16>>>,
+    writer: &mut impl Write,
+) -> io::Result<()> {
+    // TODO make RD1 and normalize mutually exclusive at compile time
+    // we need the count of kmers for an outpout like the one of Reindeer 1
+    load_kmer_counts_vector(bf_dir).expect("Failed to load from disk the kmer counts vector");
+
+    for (seq_header, color_vectors) in sequence_results {
+        write!(writer, "{seq_header}")?;
+        for abund_values in color_vectors.iter() {
+            // new color => a space
+            write!(writer, " ")?;
+            let mut start = 0;
+            let mut current = abund_values[0];
+
+            for i in 1..=abund_values.len() {
+                if i == abund_values.len() || abund_values[i] != current {
+                    let val_str = if current == 0 {
+                        "*"
+                    } else {
+                        &current.to_string()
+                    };
+                    if start + 1 == i {
+                        write!(writer, "{}:{}", start, val_str)?;
+                    } else {
+                        write!(writer, "{}-{}:{}", start, i - 1, val_str)?;
+                    }
+                    if i < abund_values.len() {
+                        write!(writer, ",")?;
+                        start = i;
+                        current = abund_values[i];
+                    }
+                }
+            }
+        }
+        writeln!(writer)?;
+    }
+    Ok(())
+}
+
+/// Write abundances per kmer like RD1.
+fn write_median_abundance(
+    bf_dir: &str,
+    sequence_results: &HashMap<String, Vec<Vec<u16>>>,
+    color_number: usize,
+    normalize: bool,
+    coverage: f32,
+    writer: &mut impl Write,
+) -> io::Result<()> {
+    writeln!(writer, "header,file,abundance")?;
+    // we need the count of kmers if we want to normalize them
+    let kmer_counts = if normalize {
+        load_kmer_counts_vector(bf_dir).expect("Failed to load from disk the kmer counts vector")
+    } else {
+        vec![color_number, 0] // TODO bizarre
+    };
+    // Compute medians for each sequence and each color, then write them out
+    for (seq_header, color_vectors) in sequence_results {
+        for (color_idx, abund_values) in color_vectors.iter().enumerate() {
+            if !abund_values.is_empty() {
+                let mut zeros_count = 0;
+                let mut non_zero_values: Vec<u16> = Vec::new();
+                abund_values.iter().for_each(|value| {
+                    if *value == 0 {
+                        zeros_count += 1;
+                    } else {
+                        non_zero_values.push(*value);
+                    }
+                });
+                if !non_zero_values.is_empty()
+                    && (((zeros_count as f32) / (abund_values.len() as f32)) < coverage)
+                {
+                    let mut abund_sorted = non_zero_values.clone();
+                    abund_sorted.sort_unstable();
+                    let median = if abund_sorted.iter().all(|&x| x == 0) {
+                        0
+                    } else if abund_sorted.len() == 1 {
+                        abund_sorted[0]
+                    } else {
+                        let mid = abund_sorted.len() / 2;
+                        if abund_sorted.len() % 2 == 1 {
+                            abund_sorted[mid]
+                        } else {
+                            (abund_sorted[mid - 1] + abund_sorted[mid]) / 2
+                        }
+                    };
+                    if median > 0 {
+                        let median = if normalize {
+                            median as f64 / kmer_counts[color_idx] as f64 * 1_000_000 as f64
+                        } else {
+                            median as f64
+                        };
+                        writeln!(writer, "{},{},{}", seq_header, color_idx, median)?;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn write_kmer_query(
+    fasta_file: &str,
+    bf_dir: &str,
+    color_number: usize,
+    batch_size: usize,
+    output_format: OutputFormat,
+    coverage: f32,
+    sequence_results: HashMap<String, Vec<Vec<u16>>>,
+    mut writer: &mut impl Write,
+) -> io::Result<()> {
+    match output_format {
+        OutputFormat::Colored => {
+            // TODO lrobidou discuss what this comment means:
+            // If your graph coloring wants to read from `sequence_results`:
+            // Flush the writer to separate batch outputs if needed
+            graph_coloring(fasta_file, batch_size, writer, &sequence_results)
+        }
+        OutputFormat::Raw => write_raw_abundance(bf_dir, &sequence_results, &mut writer),
+        OutputFormat::Median | OutputFormat::NormalizedMedian => {
+            let normalize = output_format == OutputFormat::NormalizedMedian;
+            write_median_abundance(
+                bf_dir,
+                &sequence_results,
+                color_number,
+                normalize,
+                coverage,
+                &mut writer,
+            )
+        }
+    }?;
+    writer.flush()?;
+    Ok(())
+}
+
 pub fn query_sequences_in_batches(
     fasta_file: &str,
     bf_dir: &str,
@@ -201,7 +339,6 @@ pub fn query_sequences_in_batches(
     let reader = read_file(fasta_file)?;
     let mut writer = BufWriter::new(File::create(output_file)?);
     // write the headr of the output csv file
-    writeln!(writer, "header,file,abundance")?;
     let base = compute_base(abundance_number, abundance_max);
 
     // Process FASTA in chunks of `batch_size` records
@@ -235,112 +372,20 @@ pub fn query_sequences_in_batches(
             .reduce(HashMap::<String, Vec<Vec<u16>>>::new, merge_results);
 
         // Now `sequence_results` has the combined data for this batch.
-        // Either color a graph or compute medians and output them.
-        match output_format {
-            OutputFormat::Colored => {
-                // If your graph coloring wants to read from `sequence_results`:
-                // Flush the writer to separate batch outputs if needed
-                let _ = writer.flush();
-                let _ = graph_coloring(fasta_file, batch_size, output_file, &sequence_results);
-            }
-            OutputFormat::Raw => {
-                // TODO make RD1 and normalize mutually exclusive at compile time
-                // we need the count of kmers for an outpout like the one of Reindeer 1
-                load_kmer_counts_vector(bf_dir)
-                    .expect("Failed to load from disk the kmer counts vector");
-
-                let err_msg = "should have been able to write the abundance";
-
-                for (seq_header, color_vectors) in &sequence_results {
-                    write!(writer, "{seq_header}").expect(err_msg);
-                    for abund_values in color_vectors.iter() {
-                        // new color => a space
-                        write!(writer, " ").expect(err_msg);
-                        let mut start = 0;
-                        let mut current = abund_values[0];
-
-                        for i in 1..=abund_values.len() {
-                            if i == abund_values.len() || abund_values[i] != current {
-                                let val_str = if current == 0 {
-                                    "*"
-                                } else {
-                                    &current.to_string()
-                                };
-                                if start + 1 == i {
-                                    write!(writer, "{}:{}", start, val_str).expect(err_msg);
-                                } else {
-                                    write!(writer, "{}-{}:{}", start, i - 1, val_str)
-                                        .expect(err_msg);
-                                }
-                                if i < abund_values.len() {
-                                    write!(writer, ",").expect(err_msg);
-                                    start = i;
-                                    current = abund_values[i];
-                                }
-                            }
-                        }
-                    }
-                    writeln!(writer).expect(err_msg);
-                }
-                let _ = writer.flush();
-            }
-            OutputFormat::Median | OutputFormat::NormalizedMedian => {
-                // we need the count of kmers if we want to normalize them
-                let normalize_option = output_format == OutputFormat::NormalizedMedian;
-                let kmer_counts = if normalize_option {
-                    load_kmer_counts_vector(bf_dir)
-                        .expect("Failed to load from disk the kmer counts vector")
-                } else {
-                    vec![color_number, 0] // TODO bizarre
-                };
-                // Compute medians for each sequence and each color, then write them out
-                for (seq_header, color_vectors) in &sequence_results {
-                    for (color_idx, abund_values) in color_vectors.iter().enumerate() {
-                        if !abund_values.is_empty() {
-                            let mut zeros_count = 0;
-                            let mut non_zero_values: Vec<u16> = Vec::new();
-                            abund_values.iter().for_each(|value| {
-                                if *value == 0 {
-                                    zeros_count += 1;
-                                } else {
-                                    non_zero_values.push(*value);
-                                }
-                            });
-                            if !non_zero_values.is_empty()
-                                && (((zeros_count as f32) / (abund_values.len() as f32)) < coverage)
-                            {
-                                let mut abund_sorted = non_zero_values.clone();
-                                abund_sorted.sort_unstable();
-                                let median = if abund_sorted.iter().all(|&x| x == 0) {
-                                    0
-                                } else if abund_sorted.len() == 1 {
-                                    abund_sorted[0]
-                                } else {
-                                    let mid = abund_sorted.len() / 2;
-                                    if abund_sorted.len() % 2 == 1 {
-                                        abund_sorted[mid]
-                                    } else {
-                                        (abund_sorted[mid - 1] + abund_sorted[mid]) / 2
-                                    }
-                                };
-                                if median > 0 {
-                                    let median = if normalize_option {
-                                        median as f64 / kmer_counts[color_idx] as f64
-                                            * 1_000_000 as f64
-                                    } else {
-                                        median as f64
-                                    };
-                                    let _ =
-                                        writeln!(writer, "{},{},{}", seq_header, color_idx, median);
-                                }
-                            }
-                        }
-                    }
-                }
-                let _ = writer.flush();
-            }
-        }
-    })?;
+        // Let's compute the output in the requested format.
+        write_kmer_query(
+            fasta_file,
+            bf_dir,
+            color_number,
+            batch_size,
+            output_format,
+            coverage,
+            sequence_results,
+            &mut writer,
+        )
+        .expect("should have been able to write the query result");
+    })
+    .expect("should have been able to process fasta files");
 
     Ok(())
 }
@@ -366,11 +411,10 @@ fn merge_results(
 pub fn graph_coloring(
     fasta_file: &str,
     batch_size: usize,
-    output_file: &str,
+    writer: &mut impl Write,
     sequence_results: &HashMap<String, Vec<Vec<u16>>>,
-) -> Result<(), Box<dyn Error>> {
+) -> std::io::Result<()> {
     let reader = read_file(fasta_file)?; // your existing read_file
-    let mut writer = BufWriter::new(File::create(output_file)?);
 
     process_fasta_in_batches(reader, batch_size, |batch| {
         for record in batch {
@@ -432,7 +476,5 @@ pub fn graph_coloring(
             }
         }
     })?;
-
-    writer.flush()?;
     Ok(())
 }

--- a/src/reindeer2/query.rs
+++ b/src/reindeer2/query.rs
@@ -249,7 +249,7 @@ pub fn query_sequences_in_batches(
                 load_kmer_counts_vector(bf_dir)
                     .expect("Failed to load from disk the kmer counts vector");
 
-                let err_msg = "should habe been able to write the abundance";
+                let err_msg = "should have been able to write the abundance";
 
                 for (seq_header, color_vectors) in &sequence_results {
                     write!(writer, "{seq_header}").expect(err_msg);

--- a/src/reindeer2/query.rs
+++ b/src/reindeer2/query.rs
@@ -12,6 +12,7 @@ use crate::reindeer2::{
     load_bloom_filter, load_dense_index, process_fasta_in_batches, read_file,
     update_color_abundances,
 };
+use crate::OutputFormat;
 
 // === QUERY ===
 
@@ -193,11 +194,9 @@ pub fn query_sequences_in_batches(
     abundance_max: u16,
     batch_size: usize,
     output_file: &str,
-    color_graph: bool,
     dense_option: bool,
-    normalize_option: bool,
+    output_format: OutputFormat,
     coverage: f32,
-    rd1_like: bool,
 ) -> io::Result<()> {
     let reader = read_file(fasta_file)?;
     let mut writer = BufWriter::new(File::create(output_file)?);
@@ -237,101 +236,109 @@ pub fn query_sequences_in_batches(
 
         // Now `sequence_results` has the combined data for this batch.
         // Either color a graph or compute medians and output them.
-        if color_graph {
-            // If your graph coloring wants to read from `sequence_results`:
-            // Flush the writer to separate batch outputs if needed
-            let _ = writer.flush();
-            let _ = graph_coloring(fasta_file, batch_size, output_file, &sequence_results);
-        } else if rd1_like {
-            // TODO make RD1 and normalize mutually exclusive at compile time
-            // we need the count of kmers for an outpout like the one of Reindeer 1
-            load_kmer_counts_vector(bf_dir)
-                .expect("Failed to load from disk the kmer counts vector");
-
-            let err_msg = "should habe been able to write the abundance";
-
-            for (seq_header, color_vectors) in &sequence_results {
-                write!(writer, "{seq_header}").expect(err_msg);
-                for abund_values in color_vectors.iter() {
-                    // new color => a space
-                    write!(writer, " ").expect(err_msg);
-                    let mut start = 0;
-                    let mut current = abund_values[0];
-
-                    for i in 1..=abund_values.len() {
-                        if i == abund_values.len() || abund_values[i] != current {
-                            let val_str = if current == 0 {
-                                "*"
-                            } else {
-                                &current.to_string()
-                            };
-                            if start + 1 == i {
-                                write!(writer, "{}:{}", start, val_str).expect(err_msg);
-                            } else {
-                                write!(writer, "{}-{}:{}", start, i - 1, val_str).expect(err_msg);
-                            }
-                            if i < abund_values.len() {
-                                write!(writer, ",").expect(err_msg);
-                                start = i;
-                                current = abund_values[i];
-                            }
-                        }
-                    }
-                }
-                writeln!(writer).expect(err_msg);
+        match output_format {
+            OutputFormat::Colored => {
+                // If your graph coloring wants to read from `sequence_results`:
+                // Flush the writer to separate batch outputs if needed
+                let _ = writer.flush();
+                let _ = graph_coloring(fasta_file, batch_size, output_file, &sequence_results);
             }
-            let _ = writer.flush();
-        } else {
-            // we need the count of kmers if we want to normalize them
-            let kmer_counts = if normalize_option {
+            OutputFormat::Raw => {
+                // TODO make RD1 and normalize mutually exclusive at compile time
+                // we need the count of kmers for an outpout like the one of Reindeer 1
                 load_kmer_counts_vector(bf_dir)
-                    .expect("Failed to load from disk the kmer counts vector")
-            } else {
-                vec![color_number, 0] // TODO bizarre
-            };
-            // Compute medians for each sequence and each color, then write them out
-            for (seq_header, color_vectors) in &sequence_results {
-                for (color_idx, abund_values) in color_vectors.iter().enumerate() {
-                    if !abund_values.is_empty() {
-                        let mut zeros_count = 0;
-                        let mut non_zero_values: Vec<u16> = Vec::new();
-                        abund_values.iter().for_each(|value| {
-                            if *value == 0 {
-                                zeros_count += 1;
-                            } else {
-                                non_zero_values.push(*value);
-                            }
-                        });
-                        if !non_zero_values.is_empty()
-                            && (((zeros_count as f32) / (abund_values.len() as f32)) < coverage)
-                        {
-                            let mut abund_sorted = non_zero_values.clone();
-                            abund_sorted.sort_unstable();
-                            let median = if abund_sorted.iter().all(|&x| x == 0) {
-                                0
-                            } else if abund_sorted.len() == 1 {
-                                abund_sorted[0]
-                            } else {
-                                let mid = abund_sorted.len() / 2;
-                                if abund_sorted.len() % 2 == 1 {
-                                    abund_sorted[mid]
+                    .expect("Failed to load from disk the kmer counts vector");
+
+                let err_msg = "should habe been able to write the abundance";
+
+                for (seq_header, color_vectors) in &sequence_results {
+                    write!(writer, "{seq_header}").expect(err_msg);
+                    for abund_values in color_vectors.iter() {
+                        // new color => a space
+                        write!(writer, " ").expect(err_msg);
+                        let mut start = 0;
+                        let mut current = abund_values[0];
+
+                        for i in 1..=abund_values.len() {
+                            if i == abund_values.len() || abund_values[i] != current {
+                                let val_str = if current == 0 {
+                                    "*"
                                 } else {
-                                    (abund_sorted[mid - 1] + abund_sorted[mid]) / 2
-                                }
-                            };
-                            if median > 0 {
-                                let median = if normalize_option {
-                                    median as f64 / kmer_counts[color_idx] as f64 * 1_000_000 as f64
-                                } else {
-                                    median as f64
+                                    &current.to_string()
                                 };
-                                let _ = writeln!(writer, "{},{},{}", seq_header, color_idx, median);
+                                if start + 1 == i {
+                                    write!(writer, "{}:{}", start, val_str).expect(err_msg);
+                                } else {
+                                    write!(writer, "{}-{}:{}", start, i - 1, val_str)
+                                        .expect(err_msg);
+                                }
+                                if i < abund_values.len() {
+                                    write!(writer, ",").expect(err_msg);
+                                    start = i;
+                                    current = abund_values[i];
+                                }
+                            }
+                        }
+                    }
+                    writeln!(writer).expect(err_msg);
+                }
+                let _ = writer.flush();
+            }
+            OutputFormat::Median | OutputFormat::NormalizedMedian => {
+                // we need the count of kmers if we want to normalize them
+                let normalize_option = output_format == OutputFormat::NormalizedMedian;
+                let kmer_counts = if normalize_option {
+                    load_kmer_counts_vector(bf_dir)
+                        .expect("Failed to load from disk the kmer counts vector")
+                } else {
+                    vec![color_number, 0] // TODO bizarre
+                };
+                // Compute medians for each sequence and each color, then write them out
+                for (seq_header, color_vectors) in &sequence_results {
+                    for (color_idx, abund_values) in color_vectors.iter().enumerate() {
+                        if !abund_values.is_empty() {
+                            let mut zeros_count = 0;
+                            let mut non_zero_values: Vec<u16> = Vec::new();
+                            abund_values.iter().for_each(|value| {
+                                if *value == 0 {
+                                    zeros_count += 1;
+                                } else {
+                                    non_zero_values.push(*value);
+                                }
+                            });
+                            if !non_zero_values.is_empty()
+                                && (((zeros_count as f32) / (abund_values.len() as f32)) < coverage)
+                            {
+                                let mut abund_sorted = non_zero_values.clone();
+                                abund_sorted.sort_unstable();
+                                let median = if abund_sorted.iter().all(|&x| x == 0) {
+                                    0
+                                } else if abund_sorted.len() == 1 {
+                                    abund_sorted[0]
+                                } else {
+                                    let mid = abund_sorted.len() / 2;
+                                    if abund_sorted.len() % 2 == 1 {
+                                        abund_sorted[mid]
+                                    } else {
+                                        (abund_sorted[mid - 1] + abund_sorted[mid]) / 2
+                                    }
+                                };
+                                if median > 0 {
+                                    let median = if normalize_option {
+                                        median as f64 / kmer_counts[color_idx] as f64
+                                            * 1_000_000 as f64
+                                    } else {
+                                        median as f64
+                                    };
+                                    let _ =
+                                        writeln!(writer, "{},{},{}", seq_header, color_idx, median);
+                                }
                             }
                         }
                     }
                 }
+                let _ = writer.flush();
             }
-            let _ = writer.flush();
         }
     })?;
 

--- a/src/reindeer2/query.rs
+++ b/src/reindeer2/query.rs
@@ -25,6 +25,7 @@ fn build_partitions_kmers(
     k: usize,
     m: usize,
     partition_number: u64,
+    canonical: bool,
 ) -> HashMap<usize, Vec<(String, u64)>> {
     let mut partition_kmers: HashMap<usize, Vec<(String, u64)>> = HashMap::new();
 
@@ -47,7 +48,8 @@ fn build_partitions_kmers(
         //    .width((k - m + 1).try_into().unwrap())
         //    .iter(seq_str.as_bytes());
 
-        for (kmer_hash, minimizer) in kmer_minimizers_seq_level(seq_str.as_bytes(), k, m) {
+        for (kmer_hash, minimizer) in kmer_minimizers_seq_level(seq_str.as_bytes(), k, m, canonical)
+        {
             //for (kmer_hash, (minimizer, _position)) in nt_hash_iterator.zip(min_iter) {
             let partition_index = (minimizer % partition_number) as usize;
             partition_kmers
@@ -334,6 +336,7 @@ pub fn query_sequences_in_batches(
     dense_option: bool,
     output_format: OutputFormat,
     coverage: f32,
+    canonical: bool,
 ) -> io::Result<()> {
     let reader = read_file(fasta_file)?;
     let mut writer = BufWriter::new(File::create(output_file)?);
@@ -342,7 +345,8 @@ pub fn query_sequences_in_batches(
 
     // Process FASTA in chunks of `batch_size` records
     process_fasta_in_batches(reader, batch_size, |batch| {
-        let partition_kmers = build_partitions_kmers(batch, k, m, partition_number as u64);
+        let partition_kmers =
+            build_partitions_kmers(batch, k, m, partition_number as u64, canonical);
 
         // --- PARALLEL PHASE: process each partition's k-mers in parallel ---
         // This will store final results for *all* sequences in this batch.

--- a/src/reindeer2/query.rs
+++ b/src/reindeer2/query.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::error::Error;
 use std::fs::File;
 use std::io::{self, BufWriter, Read, Write};
 use std::path::Path;


### PR DESCRIPTION
Adds the ability to pick canonical or non canonical k-mers during indexation.
Canonical k-mers are the default.
CLI breaking change: I  merged incompatible user output options into a single enum to prevent incorrect usage.