### PR TITLE
Fix/query speed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +773,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1183,6 +1201,7 @@ dependencies = [
  "itertools 0.14.0",
  "libc",
  "log",
+ "mimalloc",
  "num-format",
  "pelt-reindeer2",
  "rand 0.9.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ xxhash-rust = { version = "0.8.12", features = ["xxh3", "const_xxh3"] }
 itertools = "0.14.0"
 thiserror = "2.0.17"
 tar-get = "0.4.3"
+mimalloc = { version = "0.1", default-features = false }
 
 [dev-dependencies]
 rstest = "0.26.1"

--- a/src/bin/reindeer2/main.rs
+++ b/src/bin/reindeer2/main.rs
@@ -20,6 +20,9 @@ use reindeer2::reindeer2::{
 
 use crate::cli::{IndexArgs, InfosArgs, MergeArgs, QueryArgs};
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 impl OutputFormatCli {
     fn to_output_format(self, normalized: Option<u64>, breakpoints: Option<f64>) -> OutputFormat {
         match (self, normalized, breakpoints) {

--- a/src/bin/reindeer2/main.rs
+++ b/src/bin/reindeer2/main.rs
@@ -130,7 +130,7 @@ fn main() -> io::Result<()> {
                 rayon::ThreadPoolBuilder::new()
                     .num_threads(1)
                     .build_global()
-                    .unwrap();
+                    .expect("should have been able to set up the threads (maybe the setup function was called twice ?)");
                 if kmer > 32 {
                     panic!(
                         "ERROR : With the '--dense' option set to 'true', the k-mer size must be <= 32."
@@ -140,7 +140,7 @@ fn main() -> io::Result<()> {
                 rayon::ThreadPoolBuilder::new()
                     .num_threads(threads)
                     .build_global()
-                    .unwrap();
+                    .expect("should have been able to set up the threads (maybe the setup function was called twice ?)");
             }
             let abundance = if abundance > 255 && dense_option {
                 log::warn!(
@@ -290,7 +290,7 @@ fn main() -> io::Result<()> {
             rayon::ThreadPoolBuilder::new()
                 .num_threads(threads)
                 .build_global()
-                .unwrap();
+                .expect("should have been able to set up the threads (maybe the setup function was called twice ?)");
 
             let fasta_file = fasta;
             let index_dir = index;
@@ -335,7 +335,7 @@ fn main() -> io::Result<()> {
             rayon::ThreadPoolBuilder::new()
                 .num_threads(threads)
                 .build_global()
-                .unwrap();
+                .expect("should have been able to set up the threads (maybe the setup function was called twice ?)");
 
             let output_dir = output_dir.unwrap_or_else(|| {
                 format!("RD2_index_{}", rand::rng().random::<u64>()) // Generate a unique directory name

--- a/src/bin/reindeer2/memory_measure.rs
+++ b/src/bin/reindeer2/memory_measure.rs
@@ -29,9 +29,9 @@ pub fn format_int_with_spaces(mut n: i64) -> String {
 
 pub fn get_max_rss() -> i64 {
     let mut usage = MaybeUninit::<rusage>::uninit();
-    let usage = unsafe {
+    unsafe {
         getrusage(RUSAGE_SELF, usage.as_mut_ptr());
-        usage.assume_init()
-    };
+    }
+    let usage = unsafe { usage.assume_init() };
     usage.ru_maxrss
 }

--- a/src/reindeer2/query/mod.rs
+++ b/src/reindeer2/query/mod.rs
@@ -168,16 +168,18 @@ fn query_smer(
     base: f64,
     color: usize,
 ) -> ApproxAbundance {
-    let mut res = ApproxAbundance::new_absent();
-    for abundance in 0..abundance_number {
-        let position_to_check =
-            base_position + (color as u64) * (abundance_number as u64) + (abundance as u64);
+    let base_position = base_position as u32;
+    let color = color as u32;
+    let abundance_number = abundance_number as u32;
 
-        if bitmap.contains(position_to_check as u32) {
-            res = ApproxAbundance::from_position_of_hit_in_the_filter(abundance, base);
-        }
+    let start = base_position + color * abundance_number;
+    let end = start + abundance_number;
+
+    if let Some(positive_position) = bitmap.range(start..end).next_back() {
+        let abundance = (positive_position - start) as u16;
+        return ApproxAbundance::from_position_of_hit_in_the_filter(abundance, base);
     }
-    res
+    ApproxAbundance::new_absent()
 }
 
 // TOUN
@@ -261,14 +263,23 @@ pub fn merge_results(
     mut acc: HashMap<usize, Vec<Vec<(u32, ApproxAbundance)>>>,
     local: HashMap<usize, Vec<Vec<(u32, ApproxAbundance)>>>,
 ) -> HashMap<usize, Vec<Vec<(u32, ApproxAbundance)>>> {
-    for (seq_id, color_vecs) in local {
-        let entry = acc
-            .entry(seq_id)
-            .or_insert_with(|| vec![Vec::new(); color_vecs.len()]);
+    use std::collections::hash_map::Entry;
 
-        // Merge each color's abundances
-        for (color_idx, local_abunds) in color_vecs.iter().enumerate() {
-            entry[color_idx].extend(local_abunds.iter().copied());
+    for (seq_id, color_vecs) in local {
+        match acc.entry(seq_id) {
+            Entry::Occupied(mut e) => {
+                let acc_vecs = e.get_mut();
+                for (color_idx, local_abunds) in color_vecs.into_iter().enumerate() {
+                    let target = &mut acc_vecs[color_idx];
+                    // Reserve all capacity upfront — eliminates realloc churn
+                    target.reserve(local_abunds.len());
+                    target.extend_from_slice(&local_abunds);
+                }
+            }
+            Entry::Vacant(e) => {
+                // Just insert directly — no extend needed at all
+                e.insert(color_vecs);
+            }
         }
     }
     acc

--- a/src/reindeer2/query/mod.rs
+++ b/src/reindeer2/query/mod.rs
@@ -196,6 +196,7 @@ pub fn update_color_abundances(
 ) {
     debug_assert!(abundance_number < u16::MAX as usize); // TODO make this check before ?
     let abundance_number: u16 = abundance_number as u16; // TODO take u16 as parameter ?
+    #[allow(clippy::needless_range_loop, reason = "clarity")]
     for color in 0..color_number {
         let smer_approx_abundance =
             query_smer(bitmap, base_position, abundance_number, base, color);


### PR DESCRIPTION
Query time is now only a third of what it was.

- use the `range` method of roaring instead of manual iteration
- in `merge_results`, copy from a slice instead of the iterator, and do not extend if the entry is empty (suggested by an LLM)
- change the global allocator to mimalloc